### PR TITLE
Étape 8 : Tests unitaires Mocha

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -1,68 +1,48 @@
 #!/usr/bin/env node
+require('dotenv').config();
 
-/**
- * Module dependencies.
- */
+const app = require('../app');
+const debug = require('debug')('api:server');
+const http = require('http');
+const Mocha = require('mocha');
+const path = require('path');
+const mongoose = require('mongoose');
 
-var app = require('../app');
-var debug = require('debug')('api:server');
-var http = require('http');
-
-/**
- * Get port from environment and store in Express.
- */
-
-var port = normalizePort(process.env.PORT || '3000');
+const port = normalizePort(process.env.PORT || '3000');
 app.set('port', port);
 
-/**
- * Create HTTP server.
- */
+const server = http.createServer(app);
 
-var server = http.createServer(app);
+// Lance les tests Mocha puis démarre le serveur
+mongoose.connection.once('open', () => {
+  const mocha = new Mocha({ timeout: 10000 });
+  mocha.addFile(path.join(__dirname, '../tests/api.test.js'));
 
-/**
- * Listen on provided port, on all network interfaces.
- */
+  console.log('\n--- Lancement des tests ---\n');
 
-server.listen(port);
-server.on('error', onError);
-server.on('listening', onListening);
-
-/**
- * Normalize a port into a number, string, or false.
- */
+  mocha.run((failures) => {
+    if (failures) {
+      console.warn(`\n⚠️  ${failures} test(s) en échec\n`);
+    } else {
+      console.log('\n✓ Tous les tests sont passés\n');
+    }
+    console.log('--- Démarrage du serveur ---\n');
+    server.listen(port);
+    server.on('error', onError);
+    server.on('listening', onListening);
+  });
+});
 
 function normalizePort(val) {
-  var port = parseInt(val, 10);
-
-  if (isNaN(port)) {
-    // named pipe
-    return val;
-  }
-
-  if (port >= 0) {
-    // port number
-    return port;
-  }
-
+  const port = parseInt(val, 10);
+  if (isNaN(port)) return val;
+  if (port >= 0) return port;
   return false;
 }
 
-/**
- * Event listener for HTTP server "error" event.
- */
-
 function onError(error) {
-  if (error.syscall !== 'listen') {
-    throw error;
-  }
-
-  var bind = typeof port === 'string'
-    ? 'Pipe ' + port
-    : 'Port ' + port;
-
-  // handle specific listen errors with friendly messages
+  if (error.syscall !== 'listen') throw error;
+  const bind = typeof port === 'string' ? 'Pipe ' + port : 'Port ' + port;
   switch (error.code) {
     case 'EACCES':
       console.error(bind + ' requires elevated privileges');
@@ -77,14 +57,9 @@ function onError(error) {
   }
 }
 
-/**
- * Event listener for HTTP server "listening" event.
- */
-
 function onListening() {
-  var addr = server.address();
-  var bind = typeof addr === 'string'
-    ? 'pipe ' + addr
-    : 'port ' + addr.port;
+  const addr = server.address();
+  const bind = typeof addr === 'string' ? 'pipe ' + addr : 'port ' + addr.port;
+  console.log('Serveur en écoute sur le ' + bind);
   debug('Listening on ' + bind);
 }

--- a/services/catways.js
+++ b/services/catways.js
@@ -41,7 +41,7 @@ const replace = async (id, data) => {
   const catway = await Catway.findByIdAndUpdate(
     id,
     { catwayNumber: data.catwayNumber, catwayType: data.catwayType, catwayState: data.catwayState },
-    { new: true, runValidators: true, overwrite: true }
+    { returnDocument: 'after', runValidators: true, overwrite: true }
   );
   if (!catway) throw new Error('Catway non trouvé');
   return catway;
@@ -58,7 +58,7 @@ const update = async (id, data) => {
   const catway = await Catway.findByIdAndUpdate(
     id,
     data,
-    { new: true, runValidators: true }
+    { returnDocument: 'after', runValidators: true }
   );
   if (!catway) throw new Error('Catway non trouvé');
   return catway;

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,0 +1,130 @@
+require('dotenv').config();
+const { expect } = require('chai');
+const mongoose = require('mongoose');
+
+const catwaysService = require('../services/catways');
+const reservationsService = require('../services/reservations');
+
+// Données de test
+const testCatway = {
+  catwayNumber: 9999,
+  catwayType: 'short',
+  catwayState: 'état de test'
+};
+
+let createdCatwayId;
+let createdReservationId;
+
+before(async function () {
+  this.timeout(10000);
+  if (mongoose.connection.readyState === 0) {
+    await mongoose.connect(process.env.MONGODB_URI);
+  }
+  // Nettoyage préventif
+  const Catway = require('../models/catway');
+  await Catway.deleteMany({ catwayNumber: 9999 });
+  const Reservation = require('../models/reservation');
+  await Reservation.deleteMany({ catwayNumber: 9999 });
+});
+
+after(async function () {
+  // Nettoyage final des données de test
+  const Catway = require('../models/catway');
+  await Catway.deleteMany({ catwayNumber: 9999 });
+  const Reservation = require('../models/reservation');
+  await Reservation.deleteMany({ catwayNumber: 9999 });
+});
+
+// ─── CATWAYS ──────────────────────────────────────────────────────────────────
+
+describe('Catways', () => {
+
+  it('1. Lister tous les catways', async function () {
+    this.timeout(5000);
+    const catways = await catwaysService.getAll();
+    expect(catways).to.be.an('array');
+    expect(catways.length).to.be.greaterThan(0);
+  });
+
+  it('2. Créer un catway', async function () {
+    this.timeout(5000);
+    const catway = await catwaysService.create(testCatway);
+    expect(catway).to.have.property('_id');
+    expect(catway.catwayNumber).to.equal(9999);
+    expect(catway.catwayType).to.equal('short');
+    createdCatwayId = catway._id.toString();
+  });
+
+  it('3. Récupérer les détails d\'un catway', async function () {
+    this.timeout(5000);
+    const catway = await catwaysService.getById(createdCatwayId);
+    expect(catway).to.have.property('catwayNumber', 9999);
+    expect(catway).to.have.property('catwayState', 'état de test');
+  });
+
+  it('4. Modifier l\'état d\'un catway', async function () {
+    this.timeout(5000);
+    const catway = await catwaysService.update(createdCatwayId, { catwayState: 'état modifié' });
+    expect(catway.catwayState).to.equal('état modifié');
+  });
+
+  it('5. Supprimer un catway', async function () {
+    this.timeout(5000);
+    // Recréer un catway pour le supprimer (le précédent sera réutilisé pour les réservations)
+    const temp = await catwaysService.create({ catwayNumber: 9998, catwayType: 'long', catwayState: 'à supprimer' });
+    await catwaysService.remove(temp._id.toString());
+    try {
+      await catwaysService.getById(temp._id.toString());
+      throw new Error('Le catway aurait dû être supprimé');
+    } catch (err) {
+      expect(err.message).to.equal('Catway non trouvé');
+    }
+  });
+
+});
+
+// ─── RÉSERVATIONS ─────────────────────────────────────────────────────────────
+
+describe('Réservations', () => {
+
+  it('6. Créer une réservation', async function () {
+    this.timeout(5000);
+    const reservation = await reservationsService.create(9999, {
+      clientName: 'Client Test',
+      boatName: 'Bateau Test',
+      checkIn: new Date('2025-07-01'),
+      checkOut: new Date('2025-07-15')
+    });
+    expect(reservation).to.have.property('_id');
+    expect(reservation.clientName).to.equal('Client Test');
+    expect(reservation.catwayNumber).to.equal(9999);
+    createdReservationId = reservation._id.toString();
+  });
+
+  it('7. Lister les réservations d\'un catway', async function () {
+    this.timeout(5000);
+    const reservations = await reservationsService.getAllByCatway(9999);
+    expect(reservations).to.be.an('array');
+    expect(reservations.length).to.be.greaterThan(0);
+    expect(reservations[0].catwayNumber).to.equal(9999);
+  });
+
+  it('8. Récupérer les détails d\'une réservation', async function () {
+    this.timeout(5000);
+    const reservation = await reservationsService.getById(createdReservationId);
+    expect(reservation).to.have.property('clientName', 'Client Test');
+    expect(reservation).to.have.property('boatName', 'Bateau Test');
+  });
+
+  it('9. Supprimer une réservation', async function () {
+    this.timeout(5000);
+    await reservationsService.remove(createdReservationId);
+    try {
+      await reservationsService.getById(createdReservationId);
+      throw new Error('La réservation aurait dû être supprimée');
+    } catch (err) {
+      expect(err.message).to.equal('Réservation non trouvée');
+    }
+  });
+
+});


### PR DESCRIPTION
## Résumé
9 tests unitaires Mocha couvrant toutes les fonctionnalités demandées par le client. Les tests s'exécutent automatiquement au démarrage de l'application.

## Tests implémentés
### Catways
- ✔ 1. Lister tous les catways
- ✔ 2. Créer un catway
- ✔ 3. Récupérer les détails d'un catway
- ✔ 4. Modifier l'état d'un catway
- ✔ 5. Supprimer un catway

### Réservations
- ✔ 6. Créer une réservation
- ✔ 7. Lister les réservations d'un catway
- ✔ 8. Récupérer les détails d'une réservation
- ✔ 9. Supprimer une réservation

## Résultat : 9 passing

## Notes
- Les tests utilisent des données temporaires (catwayNumber 9999) nettoyées avant/après chaque run
- `bin/www` utilise l'API Mocha pour lancer les tests dès que MongoDB est connecté, avant de démarrer le serveur

Closes #8