### PR TITLE
fix: page documentation accessible sans connexion

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -46,10 +46,11 @@ router.get('/reservations', isAuthenticated, async (req, res) => {
 /**
  * @route GET /docs
  * @description Page de documentation de l'API (vue d'ensemble, tutoriel, exemples, glossaire).
- * @access Privé
+ * @access Public
  */
-router.get('/docs', isAuthenticated, (req, res) => {
-  res.render('docs', { user: req.user });
+router.get('/docs', (req, res) => {
+  const user = req.session?.token ? req.user : null;
+  res.render('docs', { user });
 });
 
 module.exports = router;


### PR DESCRIPTION
## Problème
La route `GET /docs` était protégée par `isAuthenticated`, rendant le lien vers la documentation inaccessible depuis la page d'accueil.

## Solution
Suppression du middleware `isAuthenticated` sur la route `/docs`. La page est maintenant publique, accessible depuis la page d'accueil sans connexion.

Closes #19