### PR TITLE
fix: migration dates réservations (Invalid Date)

### DIFF
--- a/scripts/migrateReservationDates.js
+++ b/scripts/migrateReservationDates.js
@@ -1,0 +1,18 @@
+require('dotenv').config();
+const mongoose = require('mongoose');
+
+const migrate = async () => {
+  await mongoose.connect(process.env.MONGODB_URI);
+  console.log('Connexion MongoDB OK');
+
+  const result = await mongoose.connection.collection('reservations').updateMany(
+    { startDate: { $exists: true } },
+    [{ $set: { checkIn: '$startDate', checkOut: '$endDate' } },
+     { $unset: ['startDate', 'endDate'] }]
+  );
+
+  console.log(`${result.modifiedCount} réservation(s) migrée(s)`);
+  mongoose.connection.close();
+};
+
+migrate().catch(console.error);


### PR DESCRIPTION
## Problème
Les réservations importées depuis `reservations.json` utilisaient les champs `startDate`/`endDate` alors que le modèle Mongoose attend `checkIn`/`checkOut`. Les dates s'affichaient en "Invalid Date" dans les vues.

## Solution
Script `scripts/migrateReservationDates.js` qui renomme les champs dans les 6 documents existants en base Atlas. Migration déjà exécutée.

Closes #21